### PR TITLE
Add live coders url command

### DIFF
--- a/ChatCommands/LiveCodersUrlCommand.cs
+++ b/ChatCommands/LiveCodersUrlCommand.cs
@@ -1,0 +1,25 @@
+﻿using Service.Core;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ChatCommands
+{
+    public class LiveCodersUrlCommand : IChatCommand
+    {
+        private const string liveCodersUrl = "https://twitch.tv/team/livecoders";
+        public string Command => "livecoders";
+
+        public string Description => "Displays Twitch URL for Live Coders team";
+
+        public TimeSpan? Cooldown => TimeSpan.FromSeconds(10);
+
+        public bool CanBeListed() => true;
+
+        public async Task Execute(IChatService service, bool isBroadcaster, string userName, ReadOnlyMemory<char> text)
+        {
+            await service.SendMessage($"Check out all the Live Coders at {liveCodersUrl}");
+        }
+    }
+}


### PR DESCRIPTION
- Resolves issue #4 
- Add new live coders URL command to display the Live Coders team Twitch URL