### PR TITLE
Adding tests and some code refactoring for #26

### DIFF
--- a/ChatCommands.Test/UptimeCommandTest.cs
+++ b/ChatCommands.Test/UptimeCommandTest.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Moq;
+using Newtonsoft.Json;
+using Service.Core;
+using Shouldly;
+using Xunit;
+
+namespace ChatCommands.Test
+{
+    public class UptimeCommandTest
+    {
+        public UptimeCommandTest()
+        {
+            Sut = new UptimeCommand();
+
+            ChatServiceMock = new Mock<IChatService>();
+        }
+
+        public Mock<IChatService> ChatServiceMock { get; set; }
+
+        public UptimeCommand Sut { get; set; }
+
+        public class Execute_Method : UptimeCommandTest
+        {
+            [Fact]
+            public async Task should_not_throw()
+            {
+                ChatServiceMock.Setup(x => x.GetUptime())
+                               .ReturnsAsync(TimeSpan.FromMinutes(97));
+                ChatServiceMock.Setup(x => x.SendMessage(It.IsAny<string>()))
+                               .ReturnsAsync(true);
+
+                await Sut.Execute(ChatServiceMock.Object, new CommandArgs());
+            }
+
+            [Fact]
+            public async Task should_format_timespan_properly()
+            {
+                ChatServiceMock.Setup(x => x.GetUptime())
+                               .ReturnsAsync(TimeSpan.FromMinutes(97));
+                string chatMessage = null;
+                ChatServiceMock.Setup(x => x.SendMessage(It.IsAny<string>()))
+                               .ReturnsAsync(true)
+                               .Callback<string>(msg => chatMessage = msg);
+
+                await Sut.Execute(ChatServiceMock.Object, new CommandArgs());
+
+                chatMessage.ShouldContain("01:37:00");
+            }
+
+            [Fact]
+            public async Task should_format_negative_timespan_properly()
+            {
+                ChatServiceMock.Setup(x => x.GetUptime())
+                               .ReturnsAsync(TimeSpan.FromMinutes(-97));
+                string chatMessage = null;
+                ChatServiceMock.Setup(x => x.SendMessage(It.IsAny<string>()))
+                               .ReturnsAsync(true)
+                               .Callback<string>(msg => chatMessage = msg);
+
+                await Sut.Execute(ChatServiceMock.Object, new CommandArgs());
+
+                chatMessage.ShouldContain("01:37:00");
+            }
+        }
+    }
+}

--- a/ChatServices/TwitchService.cs
+++ b/ChatServices/TwitchService.cs
@@ -79,8 +79,8 @@ namespace ChatServices
         private static StreamData ParseStreamMetaData(string results)
         {
             var obj = JsonConvert.DeserializeObject<JObject>(results);
-            var data = obj.GetValue("data")[0];
-            var streamData = JsonConvert.DeserializeObject<StreamData>(data.ToString());
+            var data = obj.GetValue("data").First;
+            var streamData = data.ToObject<StreamData>();
             return streamData;
         }
     }


### PR DESCRIPTION
I cleaned up the deserialization of the stream metadata in the twitch service a little bit to address possible parsing issues and added a unit test for the Uptime command to test the formatting of the uptime message.  This doesn't seem to correct any bugs as all my testing indicates that the previous code and the new code should function identically.  It is however difficult to test without an actual stream running.